### PR TITLE
Fix for #58 - about window loading

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -40,9 +40,9 @@ authors:
     orcid: https://orcid.org/0009-0007-8817-0299
 identifiers:
   - type: doi
-    value: https://doi.org/10.5281/zenodo.15013104
+    value: 10.5281/zenodo.15013104
     description: Edirom-Online Frontend
-repository-code: 'https://github.com/Edirom/Edirom-Online-Frontend'
+repository-code: https://github.com/Edirom/Edirom-Online-Frontend
 abstract: >-
   Edirom-Online Frontend is the frontend for the Edirom 
   Online which is used for the presentation and

--- a/app/controller/window/about/AboutWindow.js
+++ b/app/controller/window/about/AboutWindow.js
@@ -39,20 +39,21 @@ Ext.define('EdiromOnline.controller.window.about.AboutWindow', {
         if(view.initialized) return;
         view.initialized = true;
 
-        window.doAJAXRequest('resources/CITATION.cff',
+
+        window.doAJAXRequest('../Edirom-Online-Frontend/resources/CITATION.cff',
             'GET', {}, 
             Ext.bind(function(response){
                 
                 const citation = response.responseText;
-
+                
                 // find keys in citation
+                const title = citation.match(/^title: (.*)/m)[1];
                 const abstract = String(citation.match(/^abstract:\s>-\n(\s+.*\n)+/gm)).replace(/^abstract:\s>-\n/, '');
                 const version = citation.match(/^version: (.*)/m)[1];
-                const title = citation.match(/^title: (.*)/m)[1];
+                const releaseDate = citation.match(/^date\-released: (.*)/m)[1];
                 const license = citation.match(/^license: (.*)/m)[1];
-                const repoUrl = citation.match(/^repository\-code: '(.*)'/m)[1];
-                const releaseDate = citation.match(/^date\-released: '(.*)'/m)[1];
-                const doi = citation.match(/value: ([0-9]+\.[0-9]+\/zenodo\.[0-9]+)/)[1];
+                const repoUrl = citation.match(/^repository\-code: (.*)/m)[1];
+                const doi = citation.match(/value: .*?([0-9]+\.[0-9]+\/zenodo\.[0-9]+)/)[1];
 
                 view.setResult(`
                     <div class="tei_body">
@@ -71,9 +72,12 @@ Ext.define('EdiromOnline.controller.window.about.AboutWindow', {
                             </p>
                         </section>
                     </div>
-                    `);
+                    `);             
 
             }, this)
         );
+
+
+
     }
 });

--- a/app/controller/window/about/AboutWindow.js
+++ b/app/controller/window/about/AboutWindow.js
@@ -39,43 +39,68 @@ Ext.define('EdiromOnline.controller.window.about.AboutWindow', {
         if(view.initialized) return;
         view.initialized = true;
 
+        // Fetching content of CITATION.cff files and turn into HTML        
+        async function fetchContent(url) {
+            const response = await fetch(url);
+            const citation = await response.text();
 
-        window.doAJAXRequest('../Edirom-Online-Frontend/resources/CITATION.cff',
-            'GET', {}, 
-            Ext.bind(function(response){
-                
-                const citation = response.responseText;
-                
-                // find keys in citation
-                const title = citation.match(/^title: (.*)/m)[1];
-                const abstract = String(citation.match(/^abstract:\s>-\n(\s+.*\n)+/gm)).replace(/^abstract:\s>-\n/, '');
-                const version = citation.match(/^version: (.*)/m)[1];
-                const releaseDate = citation.match(/^date\-released: (.*)/m)[1];
-                const license = citation.match(/^license: (.*)/m)[1];
-                const repoUrl = citation.match(/^repository\-code: (.*)/m)[1];
-                const doi = citation.match(/value: .*?([0-9]+\.[0-9]+\/zenodo\.[0-9]+)/)[1];
+            const title = citation.match(/^title: (.*)/m)[1];
+            const abstract = String(citation.match(/^abstract:\s>-\n(\s+.*\n)+/gm)).replace(/^abstract:\s>-\n/, '');
+            const version = citation.match(/^version: (.*)/m)[1];
+            const releaseDate = citation.match(/^date\-released: (.*)/m)[1];
+            const license = citation.match(/^license: (.*)/m)[1];
+            const repoUrl = citation.match(/^repository\-code: (.*)/m)[1];
+            const doi = citation.match(/value: .*?([0-9]+\.[0-9]+\/zenodo\.[0-9]+)/)[1];
 
-                view.setResult(`
-                    <div class="tei_body">
-                        <h1>About ${title}</h1>
-                        <section class="teidiv0">
-                            <p>${abstract}</p>
-                            <p>Version: ${version}</p>
-                            <p>Release date: ${releaseDate}</p>
-                            <p>DOI: <a href="https://doi.org/${doi}">${doi}</a></p>
-                            <p>${getLangString('view.window.about.AboutWindow_License')}: ${license}</p>
-                            <p>GitHub: <a href="${repoUrl}">${repoUrl}</a></p>
-                            <p>Contributors: <br/>
-                                <a href="${repoUrl}/graphs/contributors" title="See contributors to ${title} GitHub project">
-                                <img height="50px" id="github-contributors" src="https://contrib.rocks/image?repo=${repoUrl.replace(/^https?:\/\/github.com\//, '')}" alt="Avatars of contributors to ${title} in GitHub" />
-                                </a>
-                            </p>
-                        </section>
-                    </div>
-                    `);             
+            const resultHTML = `                
+                <h1>About ${title}</h1>
+                <section class="teidiv0">
+                    <p>${abstract}</p>
+                    <p>Version: ${version}</p>
+                    <p>Release date: ${releaseDate}</p>
+                    <p>DOI: <a href="https://doi.org/${doi}">${doi}</a></p>
+                    <p>${getLangString('view.window.about.AboutWindow_License')}: ${license}</p>
+                    <p>GitHub: <a href="${repoUrl}">${repoUrl}</a></p>
+                    <p>Contributors: <br/>
+                        <a href="${repoUrl}/graphs/contributors" title="See contributors to ${title} GitHub project">
+                            <img height="25px" id="github-contributors" src="https://contrib.rocks/image?repo=${repoUrl.replace(/^https?:\/\/github.com\//, '')}" alt="Avatars of contributors to ${title} in GitHub" />
+                        </a>
+                    </p>
+                </section>                
+            `;
 
-            }, this)
-        );
+            return resultHTML;
+        }
+
+        // HTML for Edirom-Online description
+        const aboutPreface = `
+            <h1>About Edirom-Online</h1>
+            <section class="teidiv0">
+                <p>
+                    Edirom-Online is a web-based platform for the collaborative editing of complex scholarly digital editions. 
+                    It is based on the TEI XML standard and provides a rich set of tools for the collaborative editing of texts, images, and other media. 
+                    Edirom-Online is developed by the Edirom Project.
+                </p>
+                <p>
+                    The software consists of two main modules: the frontend and the backend.
+                    Information about the parts of the software can be found below.
+                </p>
+            </section>`;
+
+
+        // Fetching content of CITATION.cff files and set result
+        Promise.all([
+            aboutPreface,
+            fetchContent('../Edirom-Online-Frontend/resources/CITATION.cff'),
+            fetchContent('../Edirom-Online-Backend/resources/CITATION.cff')
+        ]).then(function([preface, frontend, backend]) {
+            view.setResult(`
+                <div class="tei_body">
+                    ${preface}
+                    ${frontend}
+                    ${backend}
+                </div>`);
+        });
 
 
 

--- a/app/controller/window/about/AboutWindow.js
+++ b/app/controller/window/about/AboutWindow.js
@@ -63,7 +63,7 @@ Ext.define('EdiromOnline.controller.window.about.AboutWindow', {
                     <p>GitHub: <a href="${repoUrl}">${repoUrl}</a></p>
                     <p>Contributors: <br/>
                         <a href="${repoUrl}/graphs/contributors" title="See contributors to ${title} GitHub project">
-                            <img height="25px" id="github-contributors" src="https://contrib.rocks/image?repo=${repoUrl.replace(/^https?:\/\/github.com\//, '')}" alt="Avatars of contributors to ${title} in GitHub" />
+                            <img height="50px" id="github-contributors" src="https://contrib.rocks/image?repo=${repoUrl.replace(/^https?:\/\/github.com\//, '')}&max=14&columns=7" alt="Avatars of contributors to ${title} in GitHub" />
                         </a>
                     </p>
                 </section>                
@@ -72,31 +72,26 @@ Ext.define('EdiromOnline.controller.window.about.AboutWindow', {
             return resultHTML;
         }
 
-        // HTML for Edirom-Online description
-        const aboutPreface = `
-            <h1>About Edirom-Online</h1>
-            <section class="teidiv0">
-                <p>
-                    Edirom-Online is a web-based platform for the collaborative editing of complex scholarly digital editions. 
-                    It is based on the TEI XML standard and provides a rich set of tools for the collaborative editing of texts, images, and other media. 
-                    Edirom-Online is developed by the Edirom Project.
-                </p>
-                <p>
-                    The software consists of two main modules: the frontend and the backend.
-                    Information about the parts of the software can be found below.
-                </p>
-            </section>`;
-
 
         // Fetching content of CITATION.cff files and set result
         Promise.all([
-            aboutPreface,
             fetchContent('../Edirom-Online-Frontend/resources/CITATION.cff'),
             fetchContent('../Edirom-Online-Backend/resources/CITATION.cff')
-        ]).then(function([preface, frontend, backend]) {
+        ]).then(function([frontend, backend]) {
             view.setResult(`
                 <div class="tei_body">
-                    ${preface}
+                    <h1>About Edirom-Online</h1>
+                    <section class="teidiv0">
+                        <p>
+                            Edirom-Online is a web-based platform for the collaborative editing of complex scholarly digital editions. 
+                            It is based on the TEI XML standard and provides a rich set of tools for the collaborative editing of texts, images, and other media. 
+                            Edirom-Online is developed by the Edirom Project.
+                        </p>
+                        <p>
+                            The software consists of two main modules: the frontend and the backend.
+                            Information about the parts of the software can be found below.
+                        </p>
+                    </section>
                     ${frontend}
                     ${backend}
                 </div>`);

--- a/build.xml
+++ b/build.xml
@@ -34,6 +34,7 @@
     </target>
 
     <target name="inject-properties">
+        <!-- copy app.js to build dir -->
         <copy file="${build.dir}/app.js" tofile="${build.dir}/app-temp.js" preservelastmodified="true">
             <filterset begintoken="@" endtoken="@">
                 <filter token="backend.url" value="${backend.url}"/>
@@ -41,6 +42,8 @@
         </copy>
         <copy file="${build.dir}/app-temp.js" tofile="${build.dir}/app.js"  overwrite="true" preservelastmodified="true"/>
         <delete file="${build.dir}/app-temp.js"/>
+        <!-- Copy CITATION.cff to resources -->
+        <copy file="${basedir}/CITATION.cff" tofile="${build.dir}/resources/CITATION.cff" overwrite="true"/>
     </target>
 
 


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
There were several problems with the not correct loading of the about page:
* path to CITATION.cff
* regex not matching content
* no support for two CITATION.cff for backend and frontend
* image size of contributors

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Closes #58 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
* built and deployed
* opening about window via button in the top-right corner

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Improvement
- Refactoring

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Frontend/blob/develop/CONTRIBUTING.md) document.
- I have added tests to cover my changes at [testing](https://github.com/Edirom/Edirom-Online-Frontend/tree/develop/testing)
- All new and existing tests passed.
