### PR TITLE
added controller.xq for redirect and copying it to xar

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -58,8 +58,11 @@
         </copy>
         <copy todir="${build.dir}" preservelastmodified="true">
             <fileset dir="${exist.dir}">
-                <include name="*.png"/>
-            </fileset>            
+                <include name="*.png"/>                
+            </fileset>       
+            <fileset dir="${basedir}">
+                <include name="controller.xq"/>
+            </fileset>     
         </copy>
         <mkdir dir="${dist.dir}"/>
         <zip basedir="${build.dir}" destfile="${dist.dir}/${project.app}-${project.version}-${DSTAMP}-${TSTAMP}.xar">

--- a/build.xml
+++ b/build.xml
@@ -58,11 +58,9 @@
         </copy>
         <copy todir="${build.dir}" preservelastmodified="true">
             <fileset dir="${exist.dir}">
-                <include name="*.png"/>                
+                <include name="*.png"/>
+                <include name="controller.xq"/>            
             </fileset>       
-            <fileset dir="${basedir}">
-                <include name="controller.xq"/>
-            </fileset>     
         </copy>
         <mkdir dir="${dist.dir}"/>
         <zip basedir="${build.dir}" destfile="${dist.dir}/${project.app}-${project.version}-${DSTAMP}-${TSTAMP}.xar">

--- a/controller.xq
+++ b/controller.xq
@@ -1,0 +1,30 @@
+xquery version "3.1";
+
+declare namespace exist="http://exist.sourceforge.net/NS/exist";
+declare namespace request="http://exist-db.org/xquery/request";
+
+declare variable $exist:path external;
+declare variable $exist:resource external;
+declare variable $exist:controller external;
+declare variable $exist:prefix external;
+declare variable $exist:root external;
+
+if ($exist:path eq "") then
+    (: forward missing / to / :)
+    <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+        <redirect url="{request:get-uri()}/"/>
+    </dispatch>
+else if ($exist:path eq "/") then
+    (: redirect root path to index.html :)
+    <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+        <redirect url="index.html"/>
+    </dispatch>
+else
+    (: everything else is passed through :)
+    <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+        <set-attribute name="exist:path" value="{$exist:path}"/>
+        <set-attribute name="exist:resource" value="{$exist:resource}"/>
+        <set-attribute name="exist:controller" value="{$exist:controller}"/>
+        <set-attribute name="exist:prefix" value="{$exist:prefix}"/>
+        <cache-control cache="yes"/>
+        </dispatch>

--- a/exist-packaging/controller.xq
+++ b/exist-packaging/controller.xq
@@ -7,7 +7,6 @@ declare variable $exist:path external;
 declare variable $exist:resource external;
 declare variable $exist:controller external;
 declare variable $exist:prefix external;
-declare variable $exist:root external;
 
 if ($exist:path eq "") then
     (: forward missing / to / :)
@@ -17,7 +16,7 @@ if ($exist:path eq "") then
 else if ($exist:path eq "/") then
     (: redirect root path to index.html :)
     <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-        <redirect url="index.html"/>
+        <forward url="index.html"/>
     </dispatch>
 else
     (: everything else is passed through :)

--- a/exist-packaging/controller.xq
+++ b/exist-packaging/controller.xq
@@ -8,14 +8,10 @@ declare variable $exist:resource external;
 declare variable $exist:controller external;
 declare variable $exist:prefix external;
 
-if ($exist:path eq '') then
+if (matches($exist:path, '^/?$')) then
     (: redirect both simple slash and missing slash to index.html :)
     <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-        <redirect url="{request:get-uri()}/{if(string-length(request:get-query-string()) gt 0) then '?' else ''}{request:get-query-string()}"/>
-    </dispatch>
-else if($exist:path eq '/') then
-     <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-        <forward url="index.html"/>
+        <redirect url="{request:get-context-path()}{$exist:prefix}{$exist:controller}/index.html{if(string-length(request:get-query-string()) gt 0) then '?' else ''}{request:get-query-string()}"/>
     </dispatch>
 else
     (: everything else is passed through :)

--- a/exist-packaging/controller.xq
+++ b/exist-packaging/controller.xq
@@ -8,14 +8,13 @@ declare variable $exist:resource external;
 declare variable $exist:controller external;
 declare variable $exist:prefix external;
 
-if ($exist:path eq "") then
-    (: forward missing / to / :)
+if ($exist:path eq '') then
+    (: redirect both simple slash and missing slash to index.html :)
     <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-        <redirect url="{request:get-uri()}/"/>
+        <redirect url="{request:get-uri()}/{if(string-length(request:get-query-string()) gt 0) then '?' else ''}{request:get-query-string()}"/>
     </dispatch>
-else if ($exist:path eq "/") then
-    (: redirect root path to index.html :)
-    <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+else if($exist:path eq '/') then
+     <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
         <forward url="index.html"/>
     </dispatch>
 else
@@ -26,4 +25,4 @@ else
         <set-attribute name="exist:controller" value="{$exist:controller}"/>
         <set-attribute name="exist:prefix" value="{$exist:prefix}"/>
         <cache-control cache="yes"/>
-        </dispatch>
+    </dispatch>


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
Problem was that clicking on Edirom Online Frontend app in eXist-db Package Manager would open a directory listing page. What it should do is display the index.html which provides direct access to one edition or a switch if there are multiple ones.
In the Backend there is a controller.xq which serves redirects. This has been taken and adpated for the frontend

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Closes #59 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
Built, deployed and opened Frontend from Package Manager -> redirects to index.html

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Bug fix (non-breaking change which fixes an issue)

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Frontend/blob/develop/CONTRIBUTING.md) document.
- I have added tests to cover my changes at [testing](https://github.com/Edirom/Edirom-Online-Frontend/tree/develop/testing)
- All new and existing tests passed.
