### PR TITLE
Ftr 65 make backend url configurable

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -3,10 +3,14 @@
     
     <import file="${basedir}/.sencha/app/build-impl.xml"/>
     
-    <property name="backend.server" value="http://localhost:8080"/>
+    <!-- info for backend -->
+    <property name="backend.protocol" value="http"/>
+    <property name="backend.host" value="localhost"/>
+    <property name="backend.port" value="8080"/>
     <property name="backend.path" value="/exist/apps/Edirom-Online-Backend/"/>
-    <property name="backend.url" value="${backend.server}${backend.path}"/>
+    <property name="backend.url" value="${backend.protocol}://${backend.host}:${backend.protocol}${backend.path}"/>
 
+    <!-- other properties -->
     <property name="project.version" value="1.0.0"/>
     <property name="project.app" value="Edirom-Online-Frontend"/>
     <property name="project.title" value="Edirom-Online Frontend"/>

--- a/build.xml
+++ b/build.xml
@@ -3,11 +3,13 @@
     
     <import file="${basedir}/.sencha/app/build-impl.xml"/>
     
-    <property name="backend.url" value="/exist/apps/Edirom-Online-Backend/"/>
+    <property name="backend.server" value="http://localhost:8080"/>
+    <property name="backend.path" value="/exist/apps/Edirom-Online-Backend/"/>
+    <property name="backend.url" value="${backend.server}${backend.path}"/>
 
     <property name="project.version" value="1.0.0"/>
     <property name="project.app" value="Edirom-Online-Frontend"/>
-    <property name="project.title" value="Edirom Online Frontend"/>
+    <property name="project.title" value="Edirom-Online Frontend"/>
     <property name="repo.target" value="${project.app}"/>
     <property name="build.dir" value="build"/>
     <property name="dist.dir" value="build-xar"/>


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
The backend can now be specified in detail to be findable from the frontend

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Closess #65 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
Using docker compose up - see main [Edirom-Online](https://github.com/Edirom/Edirom-Online) Repo

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Bug fix (non-breaking change which fixes an issue)

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Frontend/blob/develop/CONTRIBUTING.md) document.
- I have added tests to cover my changes at [testing](https://github.com/Edirom/Edirom-Online-Frontend/tree/develop/testing)
- All new and existing tests passed.
