### PR TITLE
remove printButton

### DIFF
--- a/app/view/window/TopBar.js
+++ b/app/view/window/TopBar.js
@@ -59,11 +59,6 @@ Ext.define('EdiromOnline.view.window.TopBar', {
             handler: Ext.bind(me.showViewSpecificHelp, me)
         });
 
-        me.printButton = Ext.create('Ext.button.Button', {
-            text: 'Print',
-            handler: Ext.bind(me.printButton, me)
-        });
-
         me.spaceAfterGenItems = Ext.create('Ext.toolbar.Spacer',{ xtype: 'tbspacer',
             id: me.id+'_spaceAfterGenItems',
             width: 0 });
@@ -77,7 +72,6 @@ Ext.define('EdiromOnline.view.window.TopBar', {
             me.spaceAfterGenItems/*, TODO
             me.spaceAfterViewItems,
             '->',
-            me.printButton,
             me.helpButton*/
         ];
 
@@ -172,10 +166,5 @@ Ext.define('EdiromOnline.view.window.TopBar', {
         this.window.helpPanel.toggleCollapse(true);
         //this.window.helpPanel.isHidden();
 
-    },
-    
-    //TODO
-    printButton: function(){
-        window.open('http://localhost:8089/edirompub/data/xql/edirom_printPreview.xql?&uri=' + this.window.uri + '&type=' + this.window.type);
     }
 });


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
This removes the unused and deprecated print button

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Closes #2 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
In directory of local Edirom-Online repo clone, branch develop:

```
docker compose down --volumes --remove-orphans
export FE_BRANCH=ftr-2-delete-printbutton
export EDITION_XAR=https://github.com/Edirom/EditionExample/releases/download/v0.1.1/EditionExample-0.1.1.xar
docker compose build --no-cache
docker compose up -d
```

open http://localhost:8089 -> looks good

```
unset FE_BRANCH && unset EDITION_XAR
```

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Refactoring

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Frontend/blob/develop/CONTRIBUTING.md) document.
