### PR TITLE
insert edition css link

### DIFF
--- a/app/Application.js
+++ b/app/Application.js
@@ -203,6 +203,15 @@ Ext.define('EdiromOnline.Application', {
         }else {
             app.on('ready', Ext.bind(me.openStartDocuments, me), me, {single: true});
         }
+
+        //check for 'additional_css_path' in edition preferences and insert as CSS link into HTML head
+        if (me.getController('PreferenceController').getPreference('additional_css_path', true) !== null) {
+            const editionCssLink = document.createElement("link");
+            editionCssLink.rel = 'stylesheet';
+            editionCssLink.href = this.backendURL.split('apps/')[0] + me.getController('PreferenceController').getPreference('additional_css_path', true).split("xmldb:exist:///db/")[1];
+            document.getElementsByTagName("head")[0].appendChild(editionCssLink);
+        }
+
     },
     
     initDataStores: function() {


### PR DESCRIPTION
## Description, Context and related Issue
The applied changes check for `additional_css_path` preference and insert an html link element to the corresponding CSS file.

closes #77 

## How Has This Been Tested?
Locally with corresponding edition data.

## Types of changes
- Bug fix (non-breaking change which fixes an issue)

## Overview
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
