### PR TITLE
[Ftr] ext error handle

### DIFF
--- a/app/Application.js
+++ b/app/Application.js
@@ -65,6 +65,17 @@ Ext.define('EdiromOnline.Application', {
     activeEdition: '',
     activeWork: '', 
     backendURL: '@backend.url@',
+    
+    init: function () {
+        
+        Ext.Error.handle = function(err) {
+            if (err.level === 'warn') {
+                Ext.log({msg:err.msg, level:'warn', dump:err, stack:true});
+                return true;
+            }
+        }
+        
+    },
 
     launch: function() {
         var me = this;

--- a/app/controller/LanguageController.js
+++ b/app/controller/LanguageController.js
@@ -68,7 +68,7 @@ Ext.define('EdiromOnline.controller.LanguageController', {
                 level: 'warn' //warn, error, fatal
             });
 
-            return null;
+            return key;
         }
 
         return string.replace(Ext.String.formatRe, function(m, i) {

--- a/app/controller/LanguageController.js
+++ b/app/controller/LanguageController.js
@@ -63,7 +63,7 @@ Ext.define('EdiromOnline.controller.LanguageController', {
         if(!string) {
             Ext.Error.raise({
                 msg: 'No language string found with this key',
-                key: key,
+                key: key,   
                 lang: lang,
                 level: 'warn' //warn, error, fatal
             });


### PR DESCRIPTION
## Description, Context and related Issue
Introduce Ext.Error.handle to process Ext.Error.raise before before throwing an error.

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
closes #88

## How Has This Been Tested?
built and tested with larinetten and BAZ-GA data.

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Improvement
- Refactoring

## Overview
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Frontend/blob/develop/CONTRIBUTING.md) document.
