### PR TITLE
Only show the view menu if more than one view is available

### DIFF
--- a/app/view/window/TopBar.js
+++ b/app/view/window/TopBar.js
@@ -75,6 +75,7 @@ Ext.define('EdiromOnline.view.window.TopBar', {
             me.helpButton*/
         ];
 
+        me.viewSwitch.hide();
         me.callParent();
     },
 
@@ -90,6 +91,10 @@ Ext.define('EdiromOnline.view.window.TopBar', {
 
         me.viewToMenuItem.add(view.view.id, item);
         me.viewSwitchMenu.add(item);
+
+        if(me.viewSwitchMenu.items.length > 1) {
+            me.viewSwitch.show();
+        }
     },
 
     switchView: function(view) {


### PR DESCRIPTION
## Description, Context and related Issue
View menu will be hidden until more than one view is available

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs https://github.com/Edirom/Edirom-Online-Frontend/issues/90

## How Has This Been Tested?
Edition Example

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- New feature (non-breaking change which adds functionality)
- Improvement

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Frontend/blob/develop/CONTRIBUTING.md) document.
- All new and existing tests passed.
