### PR TITLE
Always zoom to rectangle, even if the viewer was already there

### DIFF
--- a/app/view/window/source/MeasureBasedView.js
+++ b/app/view/window/source/MeasureBasedView.js
@@ -499,8 +499,6 @@ Ext.define('EdiromOnline.view.window.source.HorizontalMeasureViewer', {
     setMeasure: function(measure, measureCount) {
         var me = this;
 
-        if(me.measure == measure && me.owner.intervalSpinner.getValue() == measureCount) return;
-
         me.measure = measure;
         if(typeof measureCount != 'undefined' && typeof measureCount != 'object' ) me.owner.intervalSpinner.setValue(measureCount);
 


### PR DESCRIPTION
## Description, Context and related Issue
If the `HorizontalMeasureViewer` has displayed a measure and the parts selection changed, the viewer did not recalculate the viewport. This is fixed now.

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs https://github.com/Edirom/Edirom-Online-Frontend/issues/22

## How Has This Been Tested?
Weber Klarinettenquintett Erstdruck I

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Bug fix (non-breaking change which fixes an issue)

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Frontend/blob/develop/CONTRIBUTING.md) document.
- All new and existing tests passed.
