### PR TITLE
changed construction of frontend URL

### DIFF
--- a/app/controller/window/about/AboutWindow.js
+++ b/app/controller/window/about/AboutWindow.js
@@ -39,8 +39,18 @@ Ext.define('EdiromOnline.controller.window.about.AboutWindow', {
         if(view.initialized) return;
         view.initialized = true;
 
+        // Specify URLs of CITATION.cff files of frontend and backend
+        const backendURL = '@backend.url@';
+        const frontendURL = location.origin + location.pathname.replaceAll("/index.html", "/");
+        const frontendURLcitation = frontendURL + 'resources/CITATION.cff';
+        const backendURLcitation = backendURL + 'resources/CITATION.cff';
+
+
         // Fetching content of CITATION.cff files and turn into HTML        
         async function fetchContent(url) {
+
+            console.log("Fetching " + url);
+
             const response = await fetch(url);
             const citation = await response.text();
 
@@ -72,11 +82,10 @@ Ext.define('EdiromOnline.controller.window.about.AboutWindow', {
             return resultHTML;
         }
 
-
         // Fetching content of CITATION.cff files and set result
         Promise.all([
-            fetchContent('../resources/CITATION.cff'),
-            fetchContent('@backend.url@resources/CITATION.cff')
+            fetchContent(frontendURLcitation),
+            fetchContent(backendURLcitation)
         ]).then(function([frontend, backend]) {
             view.setResult(`
                 <div class="tei_body">
@@ -95,7 +104,31 @@ Ext.define('EdiromOnline.controller.window.about.AboutWindow', {
                     ${frontend}
                     ${backend}
                 </div>`);
-        });
+        }).catch(function(error) {
+            console.error('Error fetching CITATION.cff files:', error);
+            view.setResult(`
+                <div class="tei_body">
+                    <h1>About Edirom-Online</h1>
+                    <section class="teidiv0">
+                        <p>
+                            Edirom-Online is a web-based platform for the collaborative editing of complex scholarly digital editions.
+                            It is based on the TEI XML standard and provides a rich set of tools for the collaborative editing of texts, images, and other media.
+                            Edirom-Online is developed by the Edirom Project.
+                        </p>
+                        <p>
+                            The software consists of two main modules: the frontend and the backend.
+                            Information about the parts of the software can be found below.
+                        </p>
+                    </section>
+                    <section class="teidiv0">
+                        <p>Error fetching content from CITATION.cff files.</p>
+                        <p>URL of backend CITATION.cff file: ${backendURLcitation}</p>
+                        <p>URL of frontend CITATION.cff file: ${frontendURLcitation}</p>
+                        <p>When encountering this or other issues persistently, please create a report on <a href="https://github.com/Edirom/Edirom-Online/issues/new/choose">https://github.com/Edirom/Edirom-Online/issues/new/choose</a></p>
+                    </section>
+                </div>
+            `);
+        })
 
 
 


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
Frontend host url was not correctly derived. Changed this. 
Now the about window shows correct info fetched from backend and frontend's CITATION.cff

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs #106 

<img width="924" height="800" alt="image" src="https://github.com/user-attachments/assets/52121059-a64d-4182-8f66-558a51e94453" />


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
Tested with EditionExample and frontend running on nginx http://localhost:8089 and in eXist-db http://localhost:8080/exist/apps/Edirom-Online-Frontend/

Docker compose with respective frontend branch and edition xar specified (and unset afterwards): 
`export FE_BRANCH=fix-106-about-window-not-displaying-content && export EDITION_XAR=https://github.com/Edirom/EditionExample/releases/download/v0.1.1/EditionExample-0.1.1.xar && docker compose down --volumes --remove-orphans && docker compose build --no-cache && docker compose up -d && unset FE_BRANCH && unset EDITION_XAR`

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Bug fix (non-breaking change which fixes an issue)

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Frontend/blob/develop/CONTRIBUTING.md) document.