### PR TITLE
corrects typo TobBar

### DIFF
--- a/app/view/window/TopBar.js
+++ b/app/view/window/TopBar.js
@@ -37,7 +37,7 @@ Ext.define('EdiromOnline.view.window.TopBar', {
         me.viewSpecificItems = new Ext.util.MixedCollection();
         me.viewToMenuItem = new Ext.util.MixedCollection();
 
-        var initViewText = getLangString('view.window.TobBar_View');
+        var initViewText = getLangString('view.window.TopBar_View');
         var views = [];
 
         me.viewSwitchMenu = Ext.create('Ext.menu.Menu', {


### PR DESCRIPTION
## Description, Context and related Issue
its just a typo

Refs (https://github.com/Edirom/Edirom-Online-Frontend/issues/195)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
build and visual check

To test: check, if "Ansicht" or "View" is still correct
<img width="264" height="199" alt="typo-TobBar" src="https://github.com/user-attachments/assets/bdbd2745-2078-452c-80d4-0b448b0ce337" />

**Please note**: this only works with corresponding [PR164](https://github.com/Edirom/Edirom-Online-Backend/pull/164) in the backend