### PR TITLE
avoid prepending `backendURL` to absolute URLs

### DIFF
--- a/app/controller/AJAXController.js
+++ b/app/controller/AJAXController.js
@@ -67,7 +67,8 @@ Ext.define('EdiromOnline.controller.AJAXController', {
         if(typeof async === 'undefined')
             async = true;
 
-        url = this.application.backendURL + url;
+        if(!/^https?:\/\//.test(url))
+            url = this.application.backendURL + url;
 
         var fn = Ext.bind(function(response, options, retryNoInt) {
         


### PR DESCRIPTION
**Before:** every URL passed to the AJAX controller had `backendURL` prepended unconditionally.

**After:** `backendURL` is only prepended if the URL is relative (i.e., doesn't already start with `http://` or `https://`).