### PR TITLE
fix: correct context binding in TextFacsimileSplitView event handlers

### DIFF
--- a/app/view/window/text/TextFacsimileSplitView.js
+++ b/app/view/window/text/TextFacsimileSplitView.js
@@ -80,8 +80,8 @@ Ext.define('EdiromOnline.view.window.text.TextFacsimileSplitView', {
 
         me.callParent();
         
-        me.on('afterrender', this.createToolbarEntries, me, {single: true});
-        me.window.on('loadInternalLink', this.loadInternalId, me);
+        me.on('afterrender', me.createToolbarEntries, me, {single: true});
+        me.window.on('loadInternalLink', me.loadInternalId, me);
     },
 
     createToolbarEntries: function() {


### PR DESCRIPTION
Replace incorrect 'this' context references with 'me' to
ensure proper scope binding in event listener callbacks.
This prevents potential runtime errors when handlers are
invoked and maintains consistency with the existing code
pattern used throughout the component.