### PR TITLE
Update postprocessing of getHelp call

### DIFF
--- a/app/controller/window/HelpWindow.js
+++ b/app/controller/window/HelpWindow.js
@@ -52,10 +52,6 @@ Ext.define('EdiromOnline.controller.window.HelpWindow', {
 
                 var windowContent = response.responseText;
 
-                // replace image paths (relative backendPath to absolute backendURL)            
-                var replacee = new RegExp('src="' + me.backendPath.replace(/\/, '\/'/g), "g");
-                windowContent = windowContent.replace(replacee, 'src="' + me.backendURL);
-
                 // set window content
                 win.setContent(windowContent);
             }, me)


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
This changes the frontend to adapt to this change in the backend: https://github.com/Edirom/Edirom-Online-Backend/pull/176
The address of the server is added to the images by the backend.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
- From the Edirom-Online main repo, build with 
```
export BE_BRANCH=175-uniform-getText-getHelp
export FE_BRANCH=update-getHelp
docker compose down --volumes --remove-orphans && docker compose build --no-cache && docker compose up
```
- Thest the frontend by going to the help window: all the image should display correctly.
- Test the backend by going to https://edirom.github.io/Edirom-Online-API/#/Other/getHelp and checking visually the response. Look for the image addresses.


