### PR TITLE
feat: restore global toggle button states from session

### DIFF
--- a/app/controller/desktop/TaskBar.js
+++ b/app/controller/desktop/TaskBar.js
@@ -45,7 +45,15 @@ Ext.define('EdiromOnline.controller.desktop.TaskBar', {
 
     onTaskbarRendered: function(taskbar) {
         this.taskbars.push(taskbar);
-        /*this.updateLanguageButton();*/
+
+        // Restore global toggle button states from sessionStorage on page load
+        var types = { measures: 'icon_toggleMeasuresGlobally', annotations: 'icon_toggleAnnotationsGlobally' };
+        Ext.Object.each(types, function(type, iconId) {
+            if (sessionStorage.getItem('edirom-' + type + '-visible-global') === 'true') {
+                var icon = document.getElementById(iconId);
+                if (icon) icon.setAttribute('pressed', '');
+            }
+        });
     },
     
     onSwitchDesktop: function(num) {


### PR DESCRIPTION
Restore the pressed state of global toggle buttons for measures
and annotations from sessionStorage when the taskbar is rendered
on page load. This ensures toggle states persist across page
refreshes by checking sessionStorage and applying the pressed
attribute to the corresponding icon elements.

Closes #210