### PR TITLE
style: add !important to hidden class display

### DIFF
--- a/packages/eoTheme/sass/etc/global.scss
+++ b/packages/eoTheme/sass/etc/global.scss
@@ -107,7 +107,7 @@ span.italic {
     padding: 0 0 2px 10px;
 }
 .hidden {
-    display: none;
+    display: none !important;
 }
 
 /* part label in horizontalMeasureViewer */


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
Add the `!important` marker to the definition of the `.hidden` CSS class to really hide things it applies to.

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs https://github.com/Edirom/Edirom-Online-Frontend/issues/{ISSUE_NUMBER}

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
different data sets

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Bug fix (non-breaking change which fixes an issue)

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Frontend/blob/develop/CONTRIBUTING.md) document.
- I have added tests to cover my changes at [testing](https://github.com/Edirom/Edirom-Online-Frontend/tree/develop/testing)
- All new and existing tests passed.
