### PR TITLE
fix: correct double-encoded ampersand in digilib URL

### DIFF
--- a/app/view/window/AnnotationView.js
+++ b/app/view/window/AnnotationView.js
@@ -521,7 +521,7 @@ Ext.define('EdiromOnline.view.window.AnnotationView', {
 
 				if (me.image_server === 'digilib') {
 
-                    var shape = tplImg.append(div, [id, digilibBaseParams + "dw=600&amp;amp;dh=600" + digilibSizeParams, hiddenData, label], true);
+                    var shape = tplImg.append(div, [id, digilibBaseParams + "dw=600&amp;dh=600" + digilibSizeParams, hiddenData, label], true);
                     shape.on('dblclick', me.participantClickedGrid, me, {participant: id});
     
                     elems.push(shape);
@@ -638,7 +638,7 @@ Ext.define('EdiromOnline.view.window.AnnotationView', {
 
             }else{
 				if (me.image_server === 'digilib') {
-                    shape = tplImg.append(div, [digilibBaseParams + "dw=600&amp;amp;dh=600" + digilibSizeParams, hiddenData, label], true);
+                    shape = tplImg.append(div, [digilibBaseParams + "dw=600&amp;dh=600" + digilibSizeParams, hiddenData, label], true);
     
                 	shape.setWidth('100%');
                 	shape.setHeight('100%');

--- a/app/view/window/AnnotationView.js
+++ b/app/view/window/AnnotationView.js
@@ -526,7 +526,7 @@ Ext.define('EdiromOnline.view.window.AnnotationView', {
     
                     elems.push(shape);
     
-                    var imgData = Ext.JSON.decode(hiddenData);
+                    var imgData = hiddenData;
     
                     if(imgData.height / imgData.width > 2.0)
                         tall |= true;


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
Fix double encoded ampersand in digilib image server URI for annotation previews

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs #214 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
Locally

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Bug fix (non-breaking change which fixes an issue)

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Frontend/blob/develop/CONTRIBUTING.md) document.
Frontend/tree/develop/testing)

Together with corresponding Backend pull request https://github.com/Edirom/Edirom-Online-Backend/pull/178
closes #214