### PR TITLE
FIX: app throws an error if configjson not found

### DIFF
--- a/app/Application.js
+++ b/app/Application.js
@@ -82,6 +82,9 @@ Ext.define('EdiromOnline.Application', {
 
         me.getController('ConfigController').loadConfig(function (config) {
             me.backendURL = config.backendURL;
+            EdiromOnline.model.Edition.updateProxyUrl(me.backendURL);
+            EdiromOnline.model.Work.updateProxyUrl(me.backendURL);
+            EdiromOnline.model.Annotation.updateProxyUrl(me.backendURL);
             me.initializeApplication();
         }, me);
     },

--- a/app/Application.js
+++ b/app/Application.js
@@ -65,7 +65,6 @@ Ext.define('EdiromOnline.Application', {
     
     activeEdition: '',
     activeWork: '', 
-    backendURL: '@backend.url@',
     
     init: function () {
         
@@ -82,10 +81,7 @@ Ext.define('EdiromOnline.Application', {
         var me = this;
 
         me.getController('ConfigController').loadConfig(function (config) {
-            me.backendURL = config.backendURL || me.backendURL;
-            EdiromOnline.model.Edition.updateProxyUrl(me.backendURL);
-            EdiromOnline.model.Work.updateProxyUrl(me.backendURL);
-            EdiromOnline.model.Annotation.updateProxyUrl(me.backendURL);
+            me.backendURL = config.backendURL;
             me.initializeApplication();
         }, me);
     },

--- a/app/controller/ConfigController.js
+++ b/app/controller/ConfigController.js
@@ -25,36 +25,19 @@ Ext.define('EdiromOnline.controller.ConfigController', {
             }
 
             this.config = await response.json();
-            console.info('config.json for backendURL loaded.');
+            console.info('config.json loaded.');
 
             if (callback) {
                 callback.call(scope || this, this.config);
             }
         } catch (e) {
-            console.log('No custom config.json found or syntax error – Using default configuration.');
-            this.loadDefaultConfig(callback, scope);
-        }
+            console.log('No custom config.json found or syntax error.');
+            }
     },
 
-    /**
-     * Handles errors when loading the configuration
-     * @param {Function} callback Callback function
-     * @param {Object} scope Scope for the callback
-     */
-    loadDefaultConfig: function (callback, scope) {
-        var me = this;
+    
 
-        // Fallback-Konfiguration
-        me.config = {
-            backendURL: '@backend.url@'
-        };
-
-        if (callback) {
-            Ext.callback(callback, scope || me, [me.config]);
-        }
-    },
-
-    /**
+        /**
      * Returns a configuration value
      * @param {String} key The configuration key
      * @param {*} defaultValue Default value if key doesn't exist

--- a/app/controller/window/HelpWindow.js
+++ b/app/controller/window/HelpWindow.js
@@ -24,9 +24,6 @@ Ext.define('EdiromOnline.controller.window.HelpWindow', {
         'window.HelpWindow'
     ],
 
-    backendPath: '@backend.path@',
-    backendURL: '@backend.url@',
-
     init: function() {
         this.control({
             'helpWindow': {
@@ -42,6 +39,11 @@ Ext.define('EdiromOnline.controller.window.HelpWindow', {
         if(win.initialized) return;
         win.initialized = true;
 
+        // get backend info from config
+        var configController = EdiromOnline.getApplication().getController('ConfigController');
+		var backendURL = configController.getConfig('backendURL');
+		var backendPath = configController.getConfig('backendPath');
+
         window.doAJAXRequest('data/xql/getHelp.xql',
             'GET', 
             {
@@ -53,8 +55,8 @@ Ext.define('EdiromOnline.controller.window.HelpWindow', {
                 var windowContent = response.responseText;
 
                 // replace image paths (relative backendPath to absolute backendURL)            
-                var replacee = new RegExp('src="' + me.backendPath.replace(/\/, '\/'/g), "g");
-                windowContent = windowContent.replace(replacee, 'src="' + me.backendURL);
+                var replacee = new RegExp('src="' + backendPath.replace(/\/, '\/'/g), "g");
+                windowContent = windowContent.replace(replacee, 'src="' + backendURL);
 
                 // set window content
                 win.setContent(windowContent);

--- a/app/controller/window/about/AboutWindow.js
+++ b/app/controller/window/about/AboutWindow.js
@@ -36,8 +36,9 @@ Ext.define('EdiromOnline.controller.window.about.AboutWindow', {
 
         var me = this;
 
+        // get backend info from config
         var configController = EdiromOnline.getApplication().getController('ConfigController');
-        var backendURL = configController && configController.hasConfig('backendURL') ? configController.getConfig('backendURL') : '@backend.url@';
+        var backendURL = configController.getConfig('backendURL');
 
         if (view.initialized) return;
         view.initialized = true;

--- a/app/model/Annotation.js
+++ b/app/model/Annotation.js
@@ -34,7 +34,7 @@ Ext.define('EdiromOnline.model.Annotation', {
 
     proxy: {
         type: 'ajax',
-        url: '@backend.url@data/xql/getAnnotations.xql',
+        url: 'data/xql/getAnnotations.xql',
         reader: {
             type: 'json',
             root: 'annotations',
@@ -43,7 +43,12 @@ Ext.define('EdiromOnline.model.Annotation', {
     },
 
     statics: {
-        updateProxyUrl: function (backendURL) {
+        updateProxyUrl: function () {
+
+            // get backend info from config
+            var configController = EdiromOnline.getApplication().getController('ConfigController');
+            var backendURL = configController.getConfig('backendURL');
+            
             var model = Ext.ModelManager.getModel('EdiromOnline.model.Annotation');
             if (model) {
                 model.getProxy().url = backendURL + 'data/xql/getAnnotations.xql';

--- a/app/model/Annotation.js
+++ b/app/model/Annotation.js
@@ -43,12 +43,7 @@ Ext.define('EdiromOnline.model.Annotation', {
     },
 
     statics: {
-        updateProxyUrl: function () {
-
-            // get backend info from config
-            var configController = EdiromOnline.getApplication().getController('ConfigController');
-            var backendURL = configController.getConfig('backendURL');
-            
+        updateProxyUrl: function (backendURL) {            
             var model = Ext.ModelManager.getModel('EdiromOnline.model.Annotation');
             if (model) {
                 model.getProxy().url = backendURL + 'data/xql/getAnnotations.xql';

--- a/app/model/Edition.js
+++ b/app/model/Edition.js
@@ -25,11 +25,16 @@ Ext.define('EdiromOnline.model.Edition', {
 
     proxy: {
         type: 'ajax',
-        url: '@backend.url@data/xql/getEdition.xql'
+        url: 'data/xql/getEdition.xql'
     },
 
     statics: {
         updateProxyUrl: function (backendURL) {
+
+            // get backend info from config
+            var configController = EdiromOnline.getApplication().getController('ConfigController');
+            var backendURL = configController.getConfig('backendURL');
+		
             var model = Ext.ModelManager.getModel('EdiromOnline.model.Edition');
             if (model) {
                 model.getProxy().url = backendURL + 'data/xql/getEdition.xql';

--- a/app/model/Edition.js
+++ b/app/model/Edition.js
@@ -30,11 +30,6 @@ Ext.define('EdiromOnline.model.Edition', {
 
     statics: {
         updateProxyUrl: function (backendURL) {
-
-            // get backend info from config
-            var configController = EdiromOnline.getApplication().getController('ConfigController');
-            var backendURL = configController.getConfig('backendURL');
-		
             var model = Ext.ModelManager.getModel('EdiromOnline.model.Edition');
             if (model) {
                 model.getProxy().url = backendURL + 'data/xql/getEdition.xql';

--- a/app/model/Work.js
+++ b/app/model/Work.js
@@ -32,16 +32,10 @@ Ext.define('EdiromOnline.model.Work', {
 
     statics: {
         updateProxyUrl: function (backendURL) {
-            
-            // get backend info from config
-            var configController = EdiromOnline.getApplication().getController('ConfigController');
-            var backendURL = configController.getConfig('backendURL');
-            
             var model = Ext.ModelManager.getModel('EdiromOnline.model.Work');
             if (model) {
                 model.getProxy().url = backendURL + 'data/xql/getWorks.xql';
             }
-
         }
     },
 });

--- a/app/model/Work.js
+++ b/app/model/Work.js
@@ -27,15 +27,21 @@ Ext.define('EdiromOnline.model.Work', {
 
     proxy: {
         type: 'ajax',
-        url: '@backend.url@data/xql/getWorks.xql'
+        url: 'data/xql/getWorks.xql'
     },
 
     statics: {
         updateProxyUrl: function (backendURL) {
+            
+            // get backend info from config
+            var configController = EdiromOnline.getApplication().getController('ConfigController');
+            var backendURL = configController.getConfig('backendURL');
+            
             var model = Ext.ModelManager.getModel('EdiromOnline.model.Work');
             if (model) {
                 model.getProxy().url = backendURL + 'data/xql/getWorks.xql';
             }
+
         }
     },
 });

--- a/app/view/window/image/VerovioImage.js
+++ b/app/view/window/image/VerovioImage.js
@@ -35,7 +35,7 @@ Ext.define('EdiromOnline.view.window.image.VerovioImage', {
 		var me = this;
 
 		var configController = EdiromOnline.getApplication().getController('ConfigController');
-		var backendURL = configController && configController.hasConfig('backendURL') ? configController.getConfig('backendURL') : '@backend.url@';
+		var backendURL = configController.getConfig('backendURL');
 
 		var html = `<html>
         		<head>

--- a/build.xml
+++ b/build.xml
@@ -83,6 +83,7 @@
         <delete file="${build.dir}/app-temp.js"/>
         <!-- Copy CITATION.cff to resources -->
         <copy file="${basedir}/CITATION.cff" tofile="${build.dir}/resources/CITATION.cff" overwrite="true"/>
+        <copy file="${basedir}/config.json" tofile="${build.dir}/config.json" overwrite="true"/>
     </target>
 
     <target name="copy-xar-resources">

--- a/config.json
+++ b/config.json
@@ -1,0 +1,4 @@
+{
+    "backendURL": "http://localhost:8080/exist/apps/Edirom-Online-Backend/",
+    "backendPath": "/exist/apps/Edirom-Online-Backend/"
+}


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
Adds a config.json to the repo, assumes it necessary so that error thrown is correct.

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs Edirom/Edirom-Online#143 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
`export FE_BRANCH=bug-143-app-throws-an-error-if-configjson-not-found && export BE_BRANCH=develop && docker compose down --volumes --remove-orphans && docker compose build --no-cache && docker compose up `

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- New feature (non-breaking change which adds functionality)
- Improvement

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Frontend/blob/develop/CONTRIBUTING.md) document.
- I have added tests to cover my changes at [testing](https://github.com/Edirom/Edirom-Online-Frontend/tree/develop/testing)
- All new and existing tests passed.
