### PR TITLE
fix/horizontal-measure-viewers-zoom

### DIFF
--- a/app/view/window/image/ImageViewer.js
+++ b/app/view/window/image/ImageViewer.js
@@ -101,7 +101,7 @@ Ext.define('EdiromOnline.view.window.image.ImageViewer', {
         me.callParent();
 
         me.on('afterrender', me.initSurface, me, {single: true});
-        me.on('resize', me.calculateHiResImg, me);
+        me.on('resize', me.onResize, me);
     },
 
     initSurface: function() {
@@ -171,6 +171,8 @@ Ext.define('EdiromOnline.view.window.image.ImageViewer', {
 
         me.imgWidth = 0;
         me.imgHeight = 0;
+
+        me.rect = null;
 
     },
 
@@ -671,8 +673,19 @@ Ext.define('EdiromOnline.view.window.image.ImageViewer', {
     },
 
     showRect: function(x, y, width, height, highlight) {
-    
+
         var me = this;
+
+        // Remember the rect so onResize can re-fit it: this keeps the displayed zone height
+        // equal across the horizontal viewers in measureBasedView even when the layout settles
+        // its container sizes over several passes – matching OpenSeaDragonViewer.
+        me.rect = {
+            x:x,
+            y:y,
+            width:width,
+            height:height,
+            highlight:highlight
+        };
 
         me.hiResImg.hide();
 
@@ -702,10 +715,22 @@ Ext.define('EdiromOnline.view.window.image.ImageViewer', {
             Ext.defer(me.createTempRect, 1000, me, [x, y, width, height], false);
 
         me.calculateHiResImg();
-        
+
         Ext.defer(me.calculateHiResImg, 500, me);
     },
-    
+
+    onResize: function() {
+
+        var me = this;
+
+        // Re-fit the stored rect to the (now final) container size so the zone keeps the same
+        // displayed height across viewers; fall back to a hi-res refresh when nothing is shown.
+        if(me.rect && me.rect != null)
+            me.showRect(me.rect.x, me.rect.y, me.rect.width, me.rect.height, false);
+        else
+            me.calculateHiResImg();
+    },
+
     getActualRect: function() {
     
         var me = this;

--- a/app/view/window/image/OpenSeaDragonViewer.js
+++ b/app/view/window/image/OpenSeaDragonViewer.js
@@ -72,6 +72,7 @@ Ext.define('EdiromOnline.view.window.image.OpenSeaDragonViewer', {
         me.callParent();
 
         me.on('afterrender', me.initSurface, me, {single: true});
+        me.on('resize', me.onResize, me);
     },
 
     initSurface: function() {
@@ -81,6 +82,13 @@ Ext.define('EdiromOnline.view.window.image.OpenSeaDragonViewer', {
             id: me.id + '_openseadragon',
             showNavigator:  false,
             showNavigationControl: false,
+            // Disable OSD's own resize polling: its built-in resize branches either freeze the
+            // pixel scale or re-fit the full (letterboxed) viewport bounds, neither of which
+            // keeps the displayed zone height equal across the horizontal viewers in
+            // measureBasedView. We handle resize ourselves in onResize() and re-fit the stored
+            // zone instead, so every viewer renders its zone at the same height – also after a
+            // viewer is added or removed.
+            autoResize: false,
             tileSources:   []
         });
         me.viewer.addHandler('zoom', function(event){ me.fireEvent('zoomChanged', event.zoom);});
@@ -165,8 +173,33 @@ Ext.define('EdiromOnline.view.window.image.OpenSeaDragonViewer', {
             highlight:highlight
         };
 
-        var rect = me.viewer.viewport.imageToViewportRectangle(x, y, width, height);
+        me.fitStoredRect();
+    },
+
+    fitStoredRect: function() {
+
+        var me = this;
+        if(!me.viewer || !me.rect || me.rect == null) return;
+
+        var rect = me.viewer.viewport.imageToViewportRectangle(me.rect.x, me.rect.y, me.rect.width, me.rect.height);
         me.viewer.viewport.fitBoundsWithConstraints(rect);
+    },
+
+    // Auto-resize is disabled (see initSurface), so we drive OSD's viewport sizing here.
+    // measureBasedView fires this whenever a viewer is laid out, resized, or its siblings
+    // change because one was added/removed. We sync the viewport to the new container size and
+    // re-fit the stored zone, so the zone keeps the same displayed height across all viewers.
+    onResize: function() {
+
+        var me = this;
+        if(!me.viewer) return;
+
+        var w = me.getWidth();
+        var h = me.getHeight();
+        if(w <= 0 || h <= 0) return;
+
+        me.viewer.viewport.resize(new OpenSeadragon.Point(w, h), false);
+        me.fitStoredRect();
     },
 
     addMeasures: function(shapes) {


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
Fix zoom levels of horizontal measure viewers when creating vurtual accolade due to multiple measure visibility

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs https://github.com/Edirom/Edirom-Online-Frontend/issues/224

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
diffrerent datasets

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Bug fix (non-breaking change which fixes an issue)

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Frontend/blob/develop/CONTRIBUTING.md) document.
  
  closes #224
