### PR TITLE
Fix CSS for TEI

### DIFF
--- a/packages/eoTheme/sass/etc/freidi-textView.scss
+++ b/packages/eoTheme/sass/etc/freidi-textView.scss
@@ -259,7 +259,6 @@ $underlineColor: #333333;
 		font-size: 2em;
 		margin-top: 1em;
 		margin-bottom: 0;
-		margin-left: 1em;
 	}
 	
 	h2 {
@@ -508,7 +507,7 @@ $underlineColor: #333333;
 		display: none;
 	}
 	
-	.teidiv0 > p, .teidiv0 > .listhead {
+	.teidiv0 > .listhead {
 		margin-left: 4em;
 	}
 	

--- a/packages/eoTheme/sass/etc/textView.scss
+++ b/packages/eoTheme/sass/etc/textView.scss
@@ -4,6 +4,13 @@
 }
 
 .textViewContent {
+
+	& {
+		margin-top: 1em;
+		margin-bottom: 1em;
+		margin-right: 3em;
+  		margin-left: 3em;
+	}
 	
 	h1 {
 		font-weight: bold;
@@ -11,7 +18,7 @@
 		line-height: 2em;
 		margin-top: 0;
 	}
-	.textViewContent .teidiv0 > p, .textViewContent .teidiv0 > .listhead {
+	.textViewContent .teidiv0 > .listhead {
 		margin-left: 4em;
 	}
 	h2 {

--- a/packages/eoTheme/sass/etc/textView.scss
+++ b/packages/eoTheme/sass/etc/textView.scss
@@ -18,9 +18,7 @@
 		line-height: 2em;
 		margin-top: 0;
 	}
-	.textViewContent .teidiv0 > .listhead {
-		margin-left: 4em;
-	}
+
 	h2 {
 		font-weight: bold;
 		font-size: 1.6em;
@@ -222,8 +220,11 @@
 		span.pagebreak {
 
 		}
+
 	/*other*/
-	
+		.figure, .stdheader { 
+			border: none; 
+		}
 
 	
 }

--- a/packages/eoTheme/sass/etc/textViewLegacy.scss
+++ b/packages/eoTheme/sass/etc/textViewLegacy.scss
@@ -53,7 +53,7 @@
 	}
 	
 	div.stdheader { 
-		border-bottom: 1pt solid black; 
+		border: none; 
 	}
 	
 /*??*/


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
This makes the appearance of TEI HTML nicer, i.e. no border on top of window, better indent for text content, no border on figures:

<img width="1514" height="757" alt="image" src="https://github.com/user-attachments/assets/a78ebdc0-ffe3-45ef-8fda-fd83442acbcd" />

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs #230 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
Tested with Klarinettenquintett and EditionExample

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Improvement

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Frontend/blob/develop/CONTRIBUTING.md) document.