### PR TITLE
disable annotation menu when no annotation filter is available

### DIFF
--- a/app/view/window/source/SourceView.js
+++ b/app/view/window/source/SourceView.js
@@ -165,6 +165,8 @@ Ext.define('EdiromOnline.view.window.source.SourceView', {
 
         }
 
+        if(priorities.getCount() == 0 && categories.getCount() == 0) return;
+
         if(priorities.data.length > 0) {
             var prioritiesItems = [];
             priorities.each(function(priority) {
@@ -208,6 +210,8 @@ Ext.define('EdiromOnline.view.window.source.SourceView', {
                 menu: me.annotCategoriesMenu
             });
         }
+
+        me.annotMenu.enable();
     },
 
     annotationFilterChanged: function(item, event) {
@@ -413,11 +417,12 @@ Ext.define('EdiromOnline.view.window.source.SourceView', {
         });
         me.window.getTopbar().addViewSpecificItem(me.layersMenu, me.id);
 
-        // annotations menu (used for priority and category filter)
+        // annotations menu (used for priority and category filter, disabled until priority and categories are available — see setAnnotationFilter)
         me.annotMenu =  Ext.create('Ext.button.Button', {
             text: getLangString('view.window.source.SourceView_annotationsMenu'),
             indent: false,
             cls: 'menuButton',
+            disabled: true,
             menu : {
                 items: [  ]
             }


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
Now the annotation menu is disabled and greyed out when no annotation filters (category and priority) are available.

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs #242 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
From main repo: `unset FE_REPO && unset BE_REPO && export BE_BRANCH=develop && export FE_BRANCH=242-annotations-menu && docker compose down --volumes --remove-orphans && docker compose build --no-cache && docker compose up -d`
Open different sources in Klarinettenquintett: Erstdruck has filters and the menu is enabled, Baermann has no annotations and filters and the menu is disabled.

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Bug fix (non-breaking change which fixes an issue)

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Frontend/blob/develop/CONTRIBUTING.md) document.
- All new and existing tests passed.
