### PR TITLE
241 hide concordance navigato taskbar button

### DIFF
--- a/app/view/desktop/Desktop.js
+++ b/app/view/desktop/Desktop.js
@@ -152,22 +152,20 @@ Ext.define('EdiromOnline.view.desktop.Desktop', {
             me.addWindow(thisWindow);
             thisWindow.show();
 
-        }else if(!document.getElementById('icon_openConcordanceNavigator').hasAttribute('pressed')){
-
-            // show concordance navigator window
-            thisWindow.show();
-
-            // set attribute pressed of button for opening concordance navigator in task bar
-            document.getElementById('icon_openConcordanceNavigator').setAttribute('pressed', '');
-        }
-
-        else{
+        }else if(document.getElementById('icon_openConcordanceNavigator').hasAttribute('pressed')){
 
             // hide concordance navigator window
             thisWindow.hide();
 
             // unset attribute pressed of button for opening concordance navigator in task bar
             document.getElementById('icon_openConcordanceNavigator').removeAttribute('pressed');
+        }else {
+
+            // show concordance navigator window
+            thisWindow.show();
+
+            // set attribute pressed of button for opening concordance navigator in task bar
+            document.getElementById('icon_openConcordanceNavigator').setAttribute('pressed', '');
         }
             
     },

--- a/app/view/desktop/Desktop.js
+++ b/app/view/desktop/Desktop.js
@@ -152,7 +152,7 @@ Ext.define('EdiromOnline.view.desktop.Desktop', {
             me.addWindow(thisWindow);
             thisWindow.show();
 
-        }else if(thisWindow != me.getActiveWindow()){
+        }else if(!document.getElementById('icon_openConcordanceNavigator').hasAttribute('pressed')){
 
             // show concordance navigator window
             thisWindow.show();

--- a/app/view/desktop/Desktop.js
+++ b/app/view/desktop/Desktop.js
@@ -552,7 +552,9 @@ Ext.define('EdiromOnline.view.desktop.Desktop', {
         me.add(win);
 
         win.taskButton = me.taskbar.addTaskButton(win);
-        win.animateTarget = win.taskButton.el;
+        win.animateTarget = Ext.getClassName(win) == 'EdiromOnline.view.window.concordanceNavigator.ConcordanceNavigator'
+            ? Ext.get('icon_openConcordanceNavigator')
+            : win.taskButton.el;
 
         win.on({
             activate: me.updateActiveWindow,

--- a/app/view/desktop/TaskBar.js
+++ b/app/view/desktop/TaskBar.js
@@ -298,6 +298,7 @@ Ext.define('EdiromOnline.view.desktop.TaskBar', {
         var me = this;
 
         var isSearchWin = (Ext.getClassName(win) == 'EdiromOnline.view.window.search.SearchWindow');
+        var isConcordanceNavigatorWin = (Ext.getClassName(win) == 'EdiromOnline.view.window.concordanceNavigator.ConcordanceNavigator');
 
         var config = {
             iconCls: win.iconCls,
@@ -315,7 +316,7 @@ Ext.define('EdiromOnline.view.desktop.TaskBar', {
             win: win
         };
 
-        if(isSearchWin) {
+        if(isSearchWin || isConcordanceNavigatorWin) {
             Ext.apply(config, {hidden: true});
         }
 


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
This PR hides the standard window-like concordance navigator taskbar button. This solves the confusion of having the concordance nvaigator minimized instead of closed when its window is closed.
In addition the animation is now targeting the icon_openConcordanceNavigator icon (when you open and close the concordance navigator, it goes into that direction).

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs #241 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
- `unset FE_REPO && unset BE_REPO && export BE_BRANCH=develop && export FE_BRANCH=241-hide-concordance-navigato-taskbar-button && docker compose down --volumes --remove-orphans && docker compose build --no-cache && docker compose up -d`
- Open and close the concordance navigartor several times.
- Change the status, close and reopen. See that the status is still preserved.

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Bug fix (non-breaking change which fixes an issue)

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Frontend/blob/develop/CONTRIBUTING.md) document.
- All new and existing tests passed.
