### PR TITLE
Fix: Make selection box non-editable (245)

### DIFF
--- a/app/view/window/source/MeasureBasedView.js
+++ b/app/view/window/source/MeasureBasedView.js
@@ -75,6 +75,7 @@ Ext.define('EdiromOnline.view.window.source.MeasureBasedView', {
             queryMode: 'local',
             displayField: 'name',
             valueField: 'id',
+            editable: false,
             margin: '0 0 0 0',
             id: 'mdiv_combo_' + me.id,
             hidden: true,

--- a/app/view/window/source/SourceView.js
+++ b/app/view/window/source/SourceView.js
@@ -735,6 +735,7 @@ Ext.define('EdiromOnline.view.window.source.GotoMsg', {
             queryMode: 'local',
             displayField: 'name',
             valueField: 'id',
+            editable: false,
             cls: 'gotoMovement',
             disabled: isDisabled,
             disabledCls: 'x-disabled'


### PR DESCRIPTION
## Description, Context and related Issue

The "Satz/Nummer" (movement) selector combo box in the source window's top bar was editable as a free-text field. Users could type arbitrary text instead of picking one of the existing movements, and submitting a non-existent movement resulted in a blank window with no error.

This PR sets `editable: false` on the movement combo boxes so they behave as strict pick-lists — only existing movements can be selected from the dropdown, and free-text entry is no longer possible.

Changes:
- `app/view/window/source/MeasureBasedView.js` — set `editable: false` on the top-bar movement selector (`mdivSelector`).
- `app/view/window/source/SourceView.js` — set `editable: false` on the movement combo in the "Goto" dialog, which had the same editable behavior.


fixes issue #245
## How Has This Been Tested?

Manually tested in the Edirom Online interface after rebuilding the frontend (`ant build`) and redeploying to the local eXist instance:
- Opened a source with multiple movements and confirmed the "Satz/Nummer" selector in the window top bar can no longer be typed into — only dropdown selection is possible.
- Confirmed the previous failure case (typing a non-existent movement and pressing Enter → blank window) can no longer occur.
- Verified the "Goto" dialog movement combo is likewise no longer editable.
- Confirmed selecting existing movements still navigates correctly.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Overview

- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Frontend/blob/develop/CONTRIBUTING.md) document.