### PR TITLE
fix(#237): wrap long lines and stabilize textViewContent layout

### DIFF
--- a/packages/eoTheme/sass/etc/freidi-textView.scss
+++ b/packages/eoTheme/sass/etc/freidi-textView.scss
@@ -273,7 +273,6 @@ $underlineColor: #333333;
 	}
 	
 	h3 {
-		text-align: center;
 		width: $pageWidth / 1.2;
 		
 		font-weight: normal;

--- a/packages/eoTheme/sass/etc/textView.scss
+++ b/packages/eoTheme/sass/etc/textView.scss
@@ -10,6 +10,10 @@
 		margin-bottom: 1em;
 		margin-right: 3em;
   		margin-left: 3em;
+		/* keep long lines and words from overflowing the right border (#237) */
+		max-width: 100%;
+		overflow-wrap: break-word;
+		word-wrap: break-word;
 	}
 	
 	h1 {
@@ -70,6 +74,21 @@
 		dt {font-weight: bold;}
 		span.hi {font-weight: bold;}
 		li.headless {display: none;}
+
+		/* Definition lists rendered as tables: stable two-column layout (#237) */
+		dl {
+			display: grid;
+			grid-template-columns: minmax(80px, max-content) auto;
+			width: 100%;
+			margin: 0;
+			padding: 0;
+			overflow: auto;
+		}
+		dd {
+			margin-left: 0;
+			overflow-wrap: break-word;
+			word-wrap: break-word;
+		}
 		
 	//todo	
 		span.smallcaps { font-variant: small-caps; }
@@ -224,6 +243,17 @@
 	/*other*/
 		.figure, .stdheader { 
 			border: none; 
+		}
+
+		/* keep figures and their images inside the text column (#237) */
+		figure.figure, div.figure {
+			max-width: 100%;
+			margin: auto;
+		}
+
+		figure.figure img, div.figure img {
+			max-width: 100%;
+			height: auto;
 		}
 
 	

--- a/packages/eoTheme/sass/etc/textView.scss
+++ b/packages/eoTheme/sass/etc/textView.scss
@@ -35,6 +35,7 @@
 		font-size: 1.2em;
 		font-style: italic;
 		line-height: 1.6em;
+	
 	}
 	
 	h4 {


### PR DESCRIPTION
## Description, Context and related Issue

The Help/text window rendered "wobbly": long lines did not wrap at the right border, and the indentation/layout shifted when clicking a TOC link. This happened in editions using the default frontend styling (e.g. the Edition Example). Editions that ship their own text CSS via `additional_css_path` (e.g. the Weber Klarinettenquintett) masked the problem, which is why they looked fine.

Rather than requiring every edition to include a custom stylesheet, this PR fixes the cause in the frontend's default `.textViewContent` styling so all editions render correctly out of the box.

Changes in `packages/eoTheme/sass/etc/textView.scss` (inside `.textViewContent`):
- Added `max-width: 100%` and `overflow-wrap: break-word` / `word-wrap: break-word` so long lines and long words wrap at the right border.
- Added a stable two-column layout for definition lists (`dl` as a grid + wrapping `dd`) so the layout no longer shifts when navigating via TOC links.
- Constrained figures and their images (`figure.figure` / `div.figure` and their `img`) to stay within the text column.

This mirrors the essential rules previously only available in edition-specific CSS, making them the frontend default.

Refs https://github.com/Edirom/Edirom-Online-Frontend/issues/237

## How Has This Been Tested?

- Checked in Chrome and Firefox (macOS).

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Overview

- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Frontend/blob/develop/CONTRIBUTING.md) document.