### PR TITLE
250 bug facsimiles are not centered after re arranging horizontal

### DIFF
--- a/app/view/window/image/OpenSeaDragonViewer.js
+++ b/app/view/window/image/OpenSeaDragonViewer.js
@@ -103,10 +103,6 @@ Ext.define('EdiromOnline.view.window.image.OpenSeaDragonViewer', {
     showImage: function(path, width, height, pageId) {
         var me = this;
 
-        // Coerce to numbers: width/height arrive as strings from the image store. String values
-        // leak into getActualRect() and break OpenSeadragon's imageToViewportRectangle (a string
-        // height collapses the rect to zero height), which mis-centres the facsimile when the
-        // viewpoint is restored after re-arranging windows (see issue #250).
         me.imageHeight = Number(height);
         me.imageWidth = Number(width);
         me.imgPath = path;

--- a/app/view/window/image/OpenSeaDragonViewer.js
+++ b/app/view/window/image/OpenSeaDragonViewer.js
@@ -103,8 +103,12 @@ Ext.define('EdiromOnline.view.window.image.OpenSeaDragonViewer', {
     showImage: function(path, width, height, pageId) {
         var me = this;
 
-        me.imageHeight = height;
-        me.imageWidth = width;
+        // Coerce to numbers: width/height arrive as strings from the image store. String values
+        // leak into getActualRect() and break OpenSeadragon's imageToViewportRectangle (a string
+        // height collapses the rect to zero height), which mis-centres the facsimile when the
+        // viewpoint is restored after re-arranging windows (see issue #250).
+        me.imageHeight = Number(height);
+        me.imageWidth = Number(width);
         me.imgPath = path;
         me.imgId = pageId;
 


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
After re-arranging source windows horizontally/vertically via the taskbar, facsimiles were pushed to the lower half of the window (black gap on top, cut off at bottom) instead of being centered/fit-to-page.

Root cause (found via live OpenSeadragon instrumentation): In [OpenSeaDragonViewer.js:103](vscode-file://vscode-app/Applications/Visual%20Studio%20Code-1.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), showImage stored imageWidth/imageHeight as the raw strings from the image store. When a window is rearranged, the viewpoint is saved and restored via [getContentConfig](vscode-file://vscode-app/Applications/Visual%20Studio%20Code-1.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) → getActualRect() → showRect(). getActualRect() clamps the visible region to me.imageWidth/me.imageHeight, so for the letterboxed fit-to-page view it returned a string height (e.g. "4452"). OpenSeadragon's imageToViewportRectangle(0,0,3588,"4452") collapses a string height to 0, so fitBounds({0,0,1,0}) is centered on y=0 instead of the image center, misplacing the facsimile.
<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs https://github.com/Edirom/Edirom-Online-Frontend/issues/250

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
1. Build and deploy Edirom according to the guide "docker compose down --volumes --remove-orphans && docker compose build --no-cache && docker compose up"
2. Open more than one manifest from the Edirom frontend 
3. Arrange the windows; the images in the windows should fit in the center. 

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Bug fix (non-breaking change which fixes an issue)


## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Frontend/blob/develop/CONTRIBUTING.md) document.
- I have added tests to cover my changes at [testing](https://github.com/Edirom/Edirom-Online-Frontend/tree/develop/testing)
- All new and existing tests passed.
