### PR TITLE
added CSS for centering .measure

### DIFF
--- a/packages/eoTheme/sass/etc/facsimile.scss
+++ b/packages/eoTheme/sass/etc/facsimile.scss
@@ -8,6 +8,10 @@
 		top: 0;
 	}
 
+	.measure{
+		text-align: center;
+	}
+
 	.measureInner {
  		background-color: rgba(255, 255, 255, 0.5);
 		border-radius: 15px;


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
This centers the measure numbers again (seems to got lost with getting rid of todo.css)

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs #253 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
1. Open an facsimile
2. Activate measure numbers
3. hover over measures an see numbers centered in the highlight boxes

See:
<img width="857" height="779" alt="image" src="https://github.com/user-attachments/assets/3f082a3b-97ad-4b97-95e5-ed19e4c05be3" />


## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Bug fix (non-breaking change which fixes an issue)

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Frontend/blob/develop/CONTRIBUTING.md) document.
- I have added tests to cover my changes at [testing](https://github.com/Edirom/Edirom-Online-Frontend/tree/develop/testing)
- All new and existing tests passed.
