### PR TITLE
Fix: sources react correctly to concnavigator

### DIFF
--- a/app/view/window/source/MeasureBasedView.js
+++ b/app/view/window/source/MeasureBasedView.js
@@ -243,18 +243,32 @@ Ext.define('EdiromOnline.view.window.source.MeasureBasedView', {
         if(typeof store.getById !== 'function')
             store = combo.store;
 
+        var id = combo.getValue();
 
+        var measure = store.getById(id);
+
+       
+        if(measure === null && typeof id === 'string' && id.indexOf('measure_') === 0) {
+            var measureNumber = id.substring(id.lastIndexOf('_') + 1);
+            var index = store.findExact('name', measureNumber);
+            if(index !== -1) {
+                measure = store.getAt(index);
+                combo.setValue(measure.get('id'));
+            }
+        }
+
+        // Nothing resolvable: keep the current display instead of blanking the view.
+        if(measure === null){
+        	return;
+        }
+
+        me.measures = measure;
+
+        // Hide viewers only once a measure has been resolved, to avoid a blank window
+        // when an internal/concordance link cannot be mapped to this source.
         me.viewers.each(function(v) {
             v.hide();
         });
-
-        var id = combo.getValue();
-
-        me.measures = store.getById(id);
-
-        if(me.measures === null){
-        	return;
-        }
 
         Ext.Array.each(me.measures.get('measures'), function(m) {
 

--- a/app/view/window/source/MeasureBasedView.js
+++ b/app/view/window/source/MeasureBasedView.js
@@ -248,18 +248,30 @@ Ext.define('EdiromOnline.view.window.source.MeasureBasedView', {
 
         var measure = store.getById(id);
 
-       
+        // Fallback for concordance / internal links:
+        // Single-part sources (e.g. parts prints or arrangements) store the real measure
+        // xml:id, while the concordance references a virtual id of the form
+        // 'measure_<mdivId>_<measureNumber>'. This branch is only entered when the id did
+        // not resolve directly (measure === null) AND it looks like such a virtual id
+        // (a string starting with 'measure_'). We then recover the measure by its trailing
+        // number, matched against the store's 'name' field, and sync the combo to the
+        // resolved record so the spinner shows the real measure number.
         if(measure === null && typeof id === 'string' && id.indexOf('measure_') === 0) {
             var measureNumber = id.substring(id.lastIndexOf('_') + 1);
             var index = store.findExact('name', measureNumber);
             if(index !== -1) {
                 measure = store.getAt(index);
                 combo.setValue(measure.get('id'));
+            } else {
+                console.warn('MeasureBasedView.setMeasure: could not resolve virtual measure id "' + id +
+                    '" (measure number "' + measureNumber + '" not found in the current mdiv store).');
             }
         }
 
         // Nothing resolvable: keep the current display instead of blanking the view.
         if(measure === null){
+            console.warn('MeasureBasedView.setMeasure: measure id "' + id + '" could not be resolved to a ' +
+                'measure in this source; keeping the current display.');
         	return;
         }
 


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
This adds a fallback calculation for unresolvable measure IDs by getting their index n in the store from the last ID suffix "..._..._n"

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs #249 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->
```
unset FE_REPO && unset BE_REPO && export BE_BRANCH=develop && export FE_BRANCH=249-bug-some-sources-do-not-react-correctly-to-concnavigator && docker compose down --volumes --remove-orphans && docker compose build --no-cache && docker compose up -d
```

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Bug fix (non-breaking change which fixes an issue)

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Frontend/blob/develop/CONTRIBUTING.md) document.
- I have added tests to cover my changes at [testing](https://github.com/Edirom/Edirom-Online-Frontend/tree/develop/testing)
- All new and existing tests passed.
