### PR TITLE
Initialize config.json from properties

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -73,12 +73,7 @@
 
     <target name="inject-properties">
         <!-- copy app.js to build dir -->
-        <copy file="${build.dir}/app.js" tofile="${build.dir}/app-temp.js" preservelastmodified="true">
-            <filterset begintoken="@" endtoken="@">
-                <filter token="backend.url" value="${backend.url}"/>
-                <filter token="backend.path" value="${backend.path}"/>
-            </filterset>
-        </copy>
+        <copy file="${build.dir}/app.js" tofile="${build.dir}/app-temp.js" preservelastmodified="true"/>
         <copy file="${build.dir}/app-temp.js" tofile="${build.dir}/app.js" overwrite="true" preservelastmodified="true"/>
         <delete file="${build.dir}/app-temp.js"/>
         <!-- Copy CITATION.cff to resources -->

--- a/build.xml
+++ b/build.xml
@@ -73,7 +73,7 @@
 
     <target name="inject-properties">
         <!-- copy app.js to build dir -->
-        <copy file="${build.dir}/app.js" tofile="${build.dir}/app-temp.js" preservelastmodified="true"/>
+        <copy file="${build.dir}/app.js" tofile="${build.dir}/app-temp.js" preservelastmodified="true">
             <filterset begintoken="@" endtoken="@">
                 <filter token="backend.url" value="${backend.url}"/>
                 <filter token="backend.path" value="${backend.path}"/>

--- a/build.xml
+++ b/build.xml
@@ -73,7 +73,7 @@
 
     <target name="inject-properties">
         <!-- copy app.js to build dir -->
-        <copy file="${build.dir}/app.js" tofile="${build.dir}/app-temp.js" preservelastmodified="true">
+        <copy file="${build.dir}/app.js" tofile="${build.dir}/app-temp.js" preservelastmodified="true"/>
             <filterset begintoken="@" endtoken="@">
                 <filter token="backend.url" value="${backend.url}"/>
                 <filter token="backend.path" value="${backend.path}"/>
@@ -83,7 +83,12 @@
         <delete file="${build.dir}/app-temp.js"/>
         <!-- Copy CITATION.cff to resources -->
         <copy file="${basedir}/CITATION.cff" tofile="${build.dir}/resources/CITATION.cff" overwrite="true"/>
-        <copy file="${basedir}/config.json" tofile="${build.dir}/config.json" overwrite="true"/>
+        <copy file="${basedir}/config.json" tofile="${build.dir}/config.json" overwrite="true">
+            <filterset begintoken="@" endtoken="@">
+                <filter token="backend.url" value="${backend.url}"/>
+                <filter token="backend.path" value="${backend.path}"/>
+            </filterset>
+        </copy>
     </target>
 
     <target name="copy-xar-resources">

--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
-    "backendURL": "http://localhost:8080/exist/apps/Edirom-Online-Backend/",
-    "backendPath": "/exist/apps/Edirom-Online-Backend/"
+    "backendURL": "@backend.url@",
+    "backendPath": "@backend.path@"
 }


### PR DESCRIPTION
## Description, Context and related Issue
<!--- Please describe your changes. Why is this change required? What problem does it solve? -->
With PR https://github.com/Edirom/Edirom-Online-Frontend/pull/220 the backend url and path are read dinamically from the config.json file. This invalidated the mechnism to modify the backend port in the main repo by setting a BE_PORT parameter.

With this PR the config.json is initialized with properties from the build.xml file or local.properties file, allowing the inkection of BE_PORT parameter when building with `docker compose build` in the main repo.

<!--- This project only accepts pull requests related to open issues. Please link to the issue here: -->
Refs https://github.com/Edirom/Edirom-Online-Frontend/issues/260

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran. -->

Test the frontend independently:
- Create a local.properties file in the repository root and write `backend.port=8081`
- Build with `docker run --rm -it -v /Users/francesco/Documents/Edirom-Online-Frontend:/app --name ediBuild ghcr.io/bwbohl/sencha-cmd:latest` and then `ant`
- Check the config.json file in the build folder
- Check that requests to the backend are sent to http://localhost:8081/

Test the full Edirom
- In the main repo `export BE_PORT=8081 && export FE_BRANCH=be_port-mechanism && docker compose down --volumes --remove-orphans && docker compose build --no-cache && docker compose up -d`
- Everything works with the backend on port 8081

## Types of changes
<!--- What types of changes does your code introduce? Please DELETE options that are not relevant. -->
- Bug fix (non-breaking change which fixes an issue)

## Overview
<!--- Go over all the following points, and DELETE options that are not relevant. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- I have updated the inline documentation accordingly.
- I have performed a self-review of my code, according to the [style guide](https://github.com/Edirom/Edirom-Online/blob/develop/STYLE-GUIDE.md)
- I have read the [CONTRIBUTING](https://github.com/Edirom/Edirom-Online-Frontend/blob/develop/CONTRIBUTING.md) document.
- All new and existing tests passed.
