### PR TITLE
added temporary filter for multiple ids in a single URL

### DIFF
--- a/app/controller/LinkController.js
+++ b/app/controller/LinkController.js
@@ -65,7 +65,10 @@ Ext.define('EdiromOnline.controller.LinkController', {
         }
 
 
-        Ext.Array.each(uris, function(singleUri){
+        Ext.Array.each(uris, function (singleUri) {
+
+            // THIS IS A TEMPORARY HACK TO LIMIT THE NUMBER OF INTERNAL IDS IN AN URL TO 1 BECAUSE EDIROM DESKTOP CAN NOT HANDLE MULTIPLE INTERNAL IDS YET (SEE EDIROM MOBILE). E.G. document.xml#id1#id2#id3 SHOULD BE document.xml#id1.
+            singleUri = singleUri.replace(/(#[^#]*)#.*$/, '$1');
 
             if(singleUri.match(/^edirom:\/\/#id=/)) {
                 //TODO: set attribute by id


### PR DESCRIPTION
## Description
URIs with multiple # fragments (e.g. document.xml#id1#id2) are used by the Korngold project and already supported by Edirom Mobile, but Edirom Desktop treats the whole tail as a single identifier that won't resolve. A regex now keeps only the first fragment so the link opens at the correct starting point (the first internal ID) instead of failing silently.

Refs https://github.com/Edirom/Edirom-Online-Frontend/issues/265

## How Has This Been Tested?
Tested with the Edition Example and internal Korngold data

